### PR TITLE
Demonstrate mock call history not reset between tests regardless of mockClear() called

### DIFF
--- a/tests/Administration.test.ts
+++ b/tests/Administration.test.ts
@@ -39,11 +39,12 @@ it('should call AdministrationModels constructor when the request is made throug
 });
 
 it('should return error when administration not found with given id', async () => {
-  jest
+  const mockedGetByIdMethod = jest
     .spyOn(AdministrationModel.prototype, 'getById')
     .mockImplementationOnce(async (id: string) => undefined);
 
   const res = await request(app).get('/administrations/123/invoices');
+  expect(mockedGetByIdMethod).toHaveBeenCalledTimes(1);
   expect(res.status).toEqual(HttpStatus.NOT_FOUND);
   expect(res.body).toMatchObject({
     statusCode: 404,


### PR DESCRIPTION
```
 FAIL  tests/Administration.test.ts
  ✓ should call AdministrationModels constructor when the controller is initiated directly
  ✓ should call AdministrationModels constructor when the request is made through supertest (11 ms)
  ✕ should return error when administration not found with given id (2 ms)

  ● should return error when administration not found with given id

    expect(jest.fn()).toHaveBeenCalledTimes(expected)

    Expected number of calls: 1
    Received number of calls: 2
```